### PR TITLE
docker: turn on refresh flag when adding zypper repo

### DIFF
--- a/docker/deepsea/openSUSE-15.0/Dockerfile-base
+++ b/docker/deepsea/openSUSE-15.0/Dockerfile-base
@@ -1,7 +1,7 @@
 FROM opensuse/leap:15.0
 MAINTAINER Nathan Cutler <ncutler@suse.com>
 
-RUN zypper addrepo https://download.opensuse.org/repositories/filesystems:/ceph:/mimic/openSUSE_Leap_15.0/filesystems:ceph:mimic.repo \
+RUN zypper addrepo --refresh https://download.opensuse.org/repositories/filesystems:/ceph:/mimic/openSUSE_Leap_15.0/filesystems:ceph:mimic.repo \
     && zypper --non-interactive --gpg-auto-import-keys refresh \
     && zypper --non-interactive update \
     && zypper --non-interactive install --no-recommends \

--- a/docker/deepsea/openSUSE-42.3/Dockerfile-base
+++ b/docker/deepsea/openSUSE-42.3/Dockerfile-base
@@ -1,7 +1,7 @@
 FROM opensuse/leap:42.3
 MAINTAINER Nathan Cutler <ncutler@suse.com>
 
-RUN zypper addrepo https://download.opensuse.org/repositories/filesystems:/ceph:/luminous/openSUSE_Leap_42.3/filesystems:ceph:luminous.repo \
+RUN zypper addrepo --refresh https://download.opensuse.org/repositories/filesystems:/ceph:/luminous/openSUSE_Leap_42.3/filesystems:ceph:luminous.repo \
     && zypper --non-interactive --gpg-auto-import-keys refresh \
     && zypper --non-interactive update \
     && zypper --non-interactive install --no-recommends \


### PR DESCRIPTION
The repo was not being refreshed when the rpm build container ran.

Signed-off-by: Nathan Cutler <ncutler@suse.com>