### PR TITLE
create-jenkins-node: Fix SSHLauncher call after slave-plugin update

### DIFF
--- a/create-jenkins-node.groovy
+++ b/create-jenkins-node.groovy
@@ -36,7 +36,7 @@ if (node) {
 }
 
 node = new DumbSlave(nodeName, nodeName + ' [auto]', '/opt/j', '1', Node.Mode.NORMAL, 'make-check',
-        new SSHLauncher(nodeHost, 22, credName, null, null, null, null, 0, 0, 0 ), new RetentionStrategy.Always(), new LinkedList() )
+        new SSHLauncher(nodeHost, 22, credName ), new RetentionStrategy.Always(), new LinkedList() )
 Jenkins.instance.addNode(node)
 println 'Created node "' + nodeName + '". Connecting...'
 


### PR DESCRIPTION
SSHLauncher had an incompatible API change[1][2] and our used
constructor got removed. Switch to the available constructor[3].

[1]
https://github.com/jenkinsci/ssh-slaves-plugin/releases/tag/ssh-slaves-1.30.0
[2] https://issues.jenkins-ci.org/browse/JENKINS-55353
[3]
https://javadoc.jenkins.io/plugin/ssh-slaves/hudson/plugins/sshslaves/SSHLauncher.html#%3Cinit%3E(java.lang.String,int,java.lang.String)

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>