### PR TITLE
jjb: Add multibranch job for sesdev

### DIFF
--- a/jjb/sesdev.yaml
+++ b/jjb/sesdev.yaml
@@ -1,0 +1,29 @@
+- project:
+    name: sesdev
+    repo-name: sesdev
+    repo-owner: SUSE
+    repo-credentials: susebot
+    jobs:
+      - '{name}-integration'
+
+- job-template:
+    name: '{name}-integration'
+    project-type: multibranch
+    periodic-folder-trigger: 5m
+    number-to-keep: 30
+    days-to-keep: 30
+    script-path: Jenkinsfile.integration
+    scm:
+      - github:
+          repo: '{repo-name}'
+          repo-owner: '{repo-owner}'
+          credentials-id: '{repo-credentials}'
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: current
+          discover-pr-forks-trust: permission
+          discover-pr-origin: current
+          submodule:
+            recursive: true
+          notification-context: continuous-integration/jenkins
+          filter-head-regex: ^(master|stable\-\d\.\d|PR\-\d+)$
+


### PR DESCRIPTION
sesdev is a tool to deploy SES. It's currently used by developers to
also test SES with Octopus, cephadm and ceph-salt. This is the base
for SES 7. So having testing for the whole stack is useful.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>