### PR TITLE
conf/makecheck-sle15sp2: Drop userdata and vars/deps handling

### DIFF
--- a/conf/makecheck-sle-15.2.yaml
+++ b/conf/makecheck-sle-15.2.yaml
@@ -1,15 +1,8 @@
 flavor: b2-30
-#image: makecheck-sle-15.1-x86_64
 image: minimal-sle-15.2-x86_64
 keyfile: ~/.ssh/sa
 keyname: storage-automation
 name: mkck%02d
 networks:
 - Ext-Net
-userdata: openstack/user-data.yaml
 username: root
-vars:
-  dependencies:
-  - git
-  - java
-  - ccache


### PR DESCRIPTION
It's not needed anymore.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>