### PR TITLE
jjb: Add job to test ceph-salt

### DIFF
--- a/jjb/ceph-salt.yaml
+++ b/jjb/ceph-salt.yaml
@@ -1,0 +1,29 @@
+- project:
+    name: ceph-salt
+    repo-name: ceph-salt
+    repo-owner: ceph
+    repo-credentials: susebot
+    jobs:
+      - '{name}-integration'
+
+- job-template:
+    name: '{name}-integration'
+    project-type: multibranch
+    periodic-folder-trigger: 5m
+    number-to-keep: 30
+    days-to-keep: 30
+    script-path: Jenkinsfile.integration
+    scm:
+      - github:
+          repo: '{repo-name}'
+          repo-owner: '{repo-owner}'
+          credentials-id: '{repo-credentials}'
+          branch-discovery: no-pr
+          discover-pr-forks-strategy: current
+          discover-pr-forks-trust: permission
+          discover-pr-origin: current
+          submodule:
+            recursive: true
+          notification-context: continuous-integration/suse/sesdev-integration
+          filter-head-regex: ^(master|stable\-\d\.\d|PR\-\d+)$
+


### PR DESCRIPTION
This job will enable PR testing against github.com/ceph/ceph. For
that, it will use the already available sesdev job and trigger a
sesdev run with the given ceph-salt PR.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>