### PR TITLE
jjb/deepsea: Add descrption to publish-artifacts job

### DIFF
--- a/jjb/deepsea.yaml
+++ b/jjb/deepsea.yaml
@@ -360,6 +360,10 @@
             junit-attachments: true
 - job:
     name: 'publish-artifacts'
+    description: |
+      This job does provide a artifacts file for the
+      different SES versions. It can be used by other jobs to
+      get a artifacts file via the Jenkins "copyartifacts" directive.
     concurrent: true
     node: storage-compute
     parameters:


### PR DESCRIPTION
When looking at Jenkins into the publish-artifacts job, it's not clear
what this job is suppose to do. Adding a description might help a bit.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>