### PR TITLE
Provide susebot credentials for cloning teuthology repos

### DIFF
--- a/jjb/teuthology.yaml
+++ b/jjb/teuthology.yaml
@@ -84,6 +84,7 @@
             branches:
                 - '$GIT_REF'
             basedir: 'teuthology'
+            credentials-id: 'susebot'
     wrappers:
         - workspace-cleanup
         - ansicolor
@@ -176,6 +177,7 @@
             branches:
                 - '$GIT_REF'
             basedir: 'teuthology'
+            credentials-id: 'susebot'
     wrappers:
         - workspace-cleanup
         - ansicolor


### PR DESCRIPTION
Should prevent failures like:
```
FileNotFoundException means that the credentials Jenkins is using is probably wrong. Or the user account does not have write access to the repo.
```
Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>