### PR TITLE
docker/deepsea: use --buildrequires for openSUSE-15.1

### DIFF
--- a/docker/deepsea/openSUSE-15.1/Dockerfile-rpm
+++ b/docker/deepsea/openSUSE-15.1/Dockerfile-rpm
@@ -15,7 +15,7 @@ RUN echo %_topdir $HOME/rpmbuild | tee $HOME/.rpmmacros
 RUN pwd && ls -la && cd DeepSea \
     && sudo zypper --non-interactive --gpg-auto-import-keys refresh \
     && sudo zypper --non-interactive install --no-recommends \
-           $(rpmspec --requires -q deepsea.spec.in 2>/dev/null)
+           $(rpmspec --buildrequires -q deepsea.spec.in 2>/dev/null)
 RUN cd DeepSea && make rpm
 
 #RUN mkdir repo && cp rpmbuild/RPMS/noarch/* repo && createrepo --repo deepsea_testing repo


### PR DESCRIPTION
When install dependencies for building rpm do run
rpmspec with --buildrequires instead of --requires

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>