### PR TITLE
docker/deepsea-make: use --buildrequires for openSUSE-15.1

### DIFF
--- a/docker/deepsea-make/openSUSE-15.1/Dockerfile-make
+++ b/docker/deepsea-make/openSUSE-15.1/Dockerfile-make
@@ -16,6 +16,6 @@ RUN echo %_topdir $HOME/rpmbuild | tee $HOME/.rpmmacros
 RUN pwd && ls -la && cd DeepSea \
     && sudo zypper --non-interactive --gpg-auto-import-keys refresh \
     && sudo zypper --non-interactive install --no-recommends \
-           $(rpmspec --requires -q deepsea.spec.in 2>/dev/null)
+           $(rpmspec --buildrequires -q deepsea.spec.in 2>/dev/null)
 RUN cd DeepSea && make $target || true
 RUN cd DeepSea && mkdir logs && cp junit*.xml logs


### PR DESCRIPTION
When install dependencies to build the deepsea use
rpmspec with --buildrequires instead of --requires

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>